### PR TITLE
Default resources

### DIFF
--- a/crates/moongraph/Cargo.toml
+++ b/crates/moongraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moongraph"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "Schedules and runs DAGs accessing shared resources. 🌙"
 repository = "https://github.com/schell/moongraph"

--- a/crates/moongraph/src/lib.rs
+++ b/crates/moongraph/src/lib.rs
@@ -395,13 +395,57 @@ impl<T: std::fmt::Display> std::fmt::Display for Move<T> {
     }
 }
 
-/// Specifies a graph edge/resource that can be "read" by a node.
-pub struct View<T> {
-    inner: Loan,
-    _phantom: PhantomData<T>,
+/// Used to generate a default value of a resource, if possible.
+pub trait Gen<T> {
+    fn generate() -> Option<T>;
 }
 
-impl<T: Any + Send + Sync> Deref for View<T> {
+/// Valueless type that represents the ability to generate a resource by
+/// default.
+pub struct SomeDefault;
+
+impl<T: Default> Gen<T> for SomeDefault {
+    fn generate() -> Option<T> {
+        Some(T::default())
+    }
+}
+
+/// Valueless type that represents the **inability** to generate a resource by default.
+pub struct NoDefault;
+
+impl<T> Gen<T> for NoDefault {
+    fn generate() -> Option<T> {
+        None
+    }
+}
+
+/// Immutably borrowed resource that _may_ be created by default.
+///
+/// [`View`] and [`ViewMut`] are the main way node functions interact with resources.
+///
+/// `View` has two type parameters:
+/// * `T` - The type of the resource.
+/// * `G` - The method by which the resource can be generated if it doesn't
+///   already exist. By default this is [`SomeDefault`], which denotes creating the
+///   resource using its default instance. Another option is [`NoDefault`] which
+///   fails to generate the resource.
+///
+/// ```rust
+/// use moongraph::*;
+///
+/// let mut graph = Graph::default();
+/// let default_number = graph.visit(|u: View<usize>| { *u }).map_err(|e| e.to_string());
+/// assert_eq!(Ok(0), default_number);
+///
+/// let no_number = graph.visit(|f: View<f32, NoDefault>| *f);
+/// assert!(no_number.is_err());
+/// ```
+pub struct View<T, G: Gen<T> = SomeDefault> {
+    inner: Loan,
+    _phantom: PhantomData<(T, G)>,
+}
+
+impl<T: Any + Send + Sync, G: Gen<T>> Deref for View<T, G> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -410,19 +454,26 @@ impl<T: Any + Send + Sync> Deref for View<T> {
     }
 }
 
-impl<T: Any + Send + Sync> Edges for View<T> {
+impl<T: Any + Send + Sync, G: Gen<T>> Edges for View<T, G> {
     fn reads() -> Vec<TypeKey> {
         vec![TypeKey::new::<T>()]
     }
 
     fn construct(resources: &mut TypeMap) -> Result<Self, GraphError> {
         let key = TypeKey::new::<T>();
-        let inner = resources
-            .loan(key)
-            .context(ResourceSnafu)?
-            .context(MissingSnafu {
-                name: std::any::type_name::<T>(),
-            })?;
+        let inner = match resources.loan(key).context(ResourceSnafu)? {
+            Some(inner) => inner,
+            None => {
+                let t = G::generate().context(MissingSnafu {
+                    name: std::any::type_name::<T>(),
+                })?;
+                // UNWRAP: safe because we know this type was missing
+                let _ = resources.insert_value(t).unwrap();
+                log::trace!("generated missing {}", std::any::type_name::<T>());
+                // UNWRAP: safe because we just inserted
+                resources.loan(key).unwrap().unwrap()
+            }
+        };
         Ok(View {
             inner,
             _phantom: PhantomData,
@@ -430,7 +481,7 @@ impl<T: Any + Send + Sync> Edges for View<T> {
     }
 }
 
-impl<T: std::fmt::Display + Any + Send + Sync> std::fmt::Display for View<T> {
+impl<T: std::fmt::Display + Any + Send + Sync, G: Gen<T>> std::fmt::Display for View<T, G> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let t: &T = self.inner.downcast_ref().unwrap();
         t.fmt(f)
@@ -1090,11 +1141,15 @@ impl Graph {
     }
 
     /// Get a reference to a resource in the graph.
+    ///
+    /// If the resource _does not_ exist `Ok(None)` will be returned.
     pub fn get_resource<T: Any + Send + Sync>(&self) -> Result<Option<&T>, GraphError> {
         Ok(self.resources.get_value().context(ResourceSnafu)?)
     }
 
     /// Get a mutable reference to a resource in the graph.
+    ///
+    /// If the resource _does not_ exist `Ok(None)` will be returned.
     pub fn get_resource_mut<T: Any + Send + Sync>(&mut self) -> Result<Option<&mut T>, GraphError> {
         Ok(self.resources.get_value_mut().context(ResourceSnafu)?)
     }
@@ -1504,5 +1559,17 @@ mod test {
         let run_was_all_good = graph.get_resource::<bool>().unwrap().unwrap();
         assert!(run_was_all_good, "run was not all good");
         assert_eq!(110.0, my_num, "local did not run");
+    }
+
+    #[test]
+    // Tests that Gen will generate a default for a missing resource,
+    // and that the result will be stored in the graph.
+    fn can_generate_view_default() {
+        let mut graph = Graph::default();
+        let u = graph.visit(|u: View<usize>| *u).unwrap();
+        assert_eq!(0, u);
+
+        let my_u = graph.get_resource::<usize>().unwrap();
+        assert_eq!(Some(0), my_u.copied());
     }
 }

--- a/crates/moongraph/src/tutorial_impl.rs
+++ b/crates/moongraph/src/tutorial_impl.rs
@@ -204,9 +204,16 @@
 /// ```rust
 /// use moongraph::*;
 ///
+/// #[derive(Default)]
 /// pub struct Position(f32, f32);
+///
+/// #[derive(Default)]
 /// pub struct Velocity(f32, f32);
+///
+/// #[derive(Default)]
 /// pub struct Acceleration(f32, f32);
+///
+/// #[derive(Default)]
 /// pub struct BankAccount {
 ///     interest_rate: f32,
 ///     balance: f32,
@@ -259,6 +266,8 @@
 /// ```
 ///
 /// Notice how the returned schedule shows that `add_velocity` and `compound_interest` can run together in parallel. We call this a "batch". It's possible to run all nodes in a batch at the same time because none of their borrows conflict and there are no explicit ordering constraints between them.
+///
+///
 ///
 /// ## Conclusion
 /// Hopefully by this point you have a better idea what `moongraph` is about and how to use it.


### PR DESCRIPTION
This adds the `Gen<T>` trait and `G: Gen<T>` parameter to `View` and `ViewMut`.

In practice it makes it so constructing `View<T>` or `ViewMut<T>` will generate a default value of `T` if it doesn't already exist in the graph. 

This makes it easier to construct graphs because you no longer have to add **all the resources** manually. Now you would only have to add the resources that can't be generated with `Default`.

- [x] add `G: Gen<T>` to `View`
- [x] add `G: Gen<T>` to `ViewMut`